### PR TITLE
fix default theme colours

### DIFF
--- a/paper-toggle-button.css
+++ b/paper-toggle-button.css
@@ -13,7 +13,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 :host([disabled]) {
-  opacity: 0.3;
   pointer-events: none;
 }
 
@@ -59,12 +58,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   width: 100%;
   border-radius: 8px;
   pointer-events: none;
-  opacity: 0.26;
+  opacity: 0.4;
   transition: background-color linear .08s;
 }
 
 :host([checked]) #toggleBar {
   opacity: 0.5;
+}
+
+:host([disabled]) #toggleBar {
+  background-color: #000;
+  opacity: 0.12;
 }
 
 #toggleButton {
@@ -73,7 +77,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   height: 20px;
   width: 20px;
   border-radius: 50%;
-  box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.4);
+  box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.6);
   transition: -webkit-transform linear .08s, background-color linear .08s;
   transition: transform linear .08s, background-color linear .08s;
   will-change: transform;
@@ -89,10 +93,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   transform: translate(16px, 0);
 }
 
+:host([disabled]) #toggleButton {
+  background-color: #bdbdbd;
+  opacity: 1;
+}
+
 #ink {
   position: absolute;
   top: -14px;
   left: -14px;
   width: 48px;
   height: 48px;
+  opacity: 0.5;
 }

--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -38,8 +38,9 @@ Styling toggle-button:
 <style is="custom-style">
   :root {
     --paper-toggle-button-unchecked-bar-color: #000000;
-    --paper-toggle-button-unchecked-button-color: #f1f1f1;
-    --paper-toggle-button-unchecked-ink-color: #bbb;
+    --paper-toggle-button-unchecked-button-color: #fafafa;
+    --paper-toggle-button-unchecked-ink-color: var(--dark-primary-color);
+
     --paper-toggle-button-checked-bar-color: #0f9d58;
     --paper-toggle-button-checked-button-color: #0f9d58;
     --paper-toggle-button-checked-ink-color: #0f9d58;


### PR DESCRIPTION
Mostly increased the opacity of the bar to match the examples here: http://www.google.com/design/spec/components/selection-controls.html#selection-controls-switch
(in the screenshots the opacity numbers don't really match the rendered colours, so I took the side of the screenshot)

Before:
![screen shot 2015-05-18 at 5 54 07 pm](https://cloud.githubusercontent.com/assets/1369170/7693494/ebfd6a14-fd86-11e4-9c7c-d7480d58c4e5.png)

After:
![screen shot 2015-05-18 at 5 53 48 pm](https://cloud.githubusercontent.com/assets/1369170/7693495/ee43879a-fd86-11e4-91bc-faecc9f8b3b3.png)

/cc @morethanreal 
