### PR TITLE
Add a noink attribute to hide the ripple effect

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-toggle-button",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A material design toggle button control",
   "authors": [
     "The Polymer Authors"

--- a/paper-toggle-button.css
+++ b/paper-toggle-button.css
@@ -16,6 +16,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   pointer-events: none;
 }
 
+:host([noink]) paper-ripple {
+    display: none;
+}
+
 :host(:focus) {
   outline:none;
 }

--- a/paper-toggle-button.css
+++ b/paper-toggle-button.css
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 :host([noink]) paper-ripple {
-    display: none;
+  display: none;
 }
 
 :host(:focus) {


### PR DESCRIPTION
Add a `noink` attribute to hide the ripple effect (just like `paper-button` does it).
I thought this should be done to keep consistency between paper elements.
