### PR TITLE
remove ripple pointer events

### DIFF
--- a/paper-toggle-button.css
+++ b/paper-toggle-button.css
@@ -105,4 +105,5 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   width: 48px;
   height: 48px;
   opacity: 0.5;
+  pointer-events: none;
 }


### PR DESCRIPTION
Otherwise if two buttons are too close, the ripple hijacks the click and you mis-select.
