### PR TITLE
Update paper-toggle-button.css

### DIFF
--- a/paper-toggle-button.css
+++ b/paper-toggle-button.css
@@ -29,11 +29,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 :host([checked]) .toggle-bar {
-  background-color: var(--paper-toggle-button-checked-bar-color, --google-green-500);
+  background-color: var(--paper-toggle-button-checked-bar-color, --default-primary-color);
 }
 
 :host([checked]) .toggle-button {
-  background-color: var(--paper-toggle-button-checked-button-color, --google-green-500);
+  background-color: var(--paper-toggle-button-checked-button-color, --default-primary-color);
 }
 
 :host .toggle-ink {


### PR DESCRIPTION
Wouldn't it be better to use the theme primary colors as the default style for the toggle button?
