### PR TITLE
Added @apply style mixins to key pieces of button to allow easier cus…

### DIFF
--- a/paper-toggle-button.css
+++ b/paper-toggle-button.css
@@ -22,18 +22,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 :host .toggle-bar {
   background-color: var(--paper-toggle-button-unchecked-bar-color, #000000);
+  @apply(--paper-toggle-button-unchecked-bar);
 }
 
 :host .toggle-button {
   background-color: var(--paper-toggle-button-unchecked-button-color, --paper-grey-50);
+  @apply(--paper-toggle-button-unchecked-button);
 }
 
 :host([checked]) .toggle-bar {
   background-color: var(--paper-toggle-button-checked-bar-color, --google-green-500);
+  @apply(--paper-toggle-button-checked-bar);
 }
 
 :host([checked]) .toggle-button {
   background-color: var(--paper-toggle-button-checked-button-color, --google-green-500);
+  @apply(--paper-toggle-button-checked-button);
 }
 
 :host .toggle-ink {

--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -34,6 +34,10 @@ Custom property | Description | Default
 `--paper-toggle-button-checked-bar-color` | Slider button color when the input is checked | `--google-green-500`
 `--paper-toggle-button-checked-button-color` | Button color when the input is checked | `--google-green-500`
 `--paper-toggle-button-checked-ink-color` | Selected/focus ripple color when the input is checked | `--google-green-500`
+`--paper-toggle-button-unchecked-bar` | Mixin applied to the slider when the input is not checked | `{}`
+`--paper-toggle-button-unchecked-button` | Mixin applied to the slider button when the input is not checked | `{}`
+`--paper-toggle-button-checked-bar` | Mixin applied to the slider when the input is checked | `{}`
+`--paper-toggle-button-checked-button` | Mixin applied to the slider button when the input is checked | `{}`
 
 @group Paper Elements
 @element paper-toggle-button


### PR DESCRIPTION
I implemented these changes on my fork because I need to be able to make some slight style changes to  the paper-toggle-button that aren't currently supported by PolymerElements/paper-toggle-button, and wanted to push these changes upstream.

An example could be wanting to apply a background image to the toggle-bar to add a check mark (think the Youtube autoplay toggle switch)
