### PR TITLE
fix default colour

### DIFF
--- a/paper-toggle-button.css
+++ b/paper-toggle-button.css
@@ -31,12 +31,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 :host([checked]) .toggle-bar {
-  background-color: var(--paper-toggle-button-checked-bar-color, --google-green-500);
+  background-color: var(--paper-toggle-button-checked-bar-color, --default-primary-color);
   @apply(--paper-toggle-button-checked-bar);
 }
 
 :host([checked]) .toggle-button {
-  background-color: var(--paper-toggle-button-checked-button-color, --google-green-500);
+  background-color: var(--paper-toggle-button-checked-button-color, --default-primary-color);
   @apply(--paper-toggle-button-checked-button);
 }
 
@@ -45,7 +45,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 :host([checked]) .toggle-ink {
-  color: var(--paper-toggle-button-checked-ink-color, --google-green-500);
+  color: var(--paper-toggle-button-checked-ink-color, --default-primary-color);
 }
 
 /* ID selectors should not be overriden by users. */

--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -31,9 +31,9 @@ Custom property | Description | Default
 `--paper-toggle-button-unchecked-bar-color` | Slider color when the input is not checked | `#000000`
 `--paper-toggle-button-unchecked-button-color` | Button color when the input is not checked | `--paper-grey-50`
 `--paper-toggle-button-unchecked-ink-color` | Selected/focus ripple color when the input is not checked | `--dark-primary-color`
-`--paper-toggle-button-checked-bar-color` | Slider button color when the input is checked | `--google-green-500`
-`--paper-toggle-button-checked-button-color` | Button color when the input is checked | `--google-green-500`
-`--paper-toggle-button-checked-ink-color` | Selected/focus ripple color when the input is checked | `--google-green-500`
+`--paper-toggle-button-checked-bar-color` | Slider button color when the input is checked | `--default-primary-color`
+`--paper-toggle-button-checked-button-color` | Button color when the input is checked | `--default-primary-color`
+`--paper-toggle-button-checked-ink-color` | Selected/focus ripple color when the input is checked | `--default-primary-color`
 `--paper-toggle-button-unchecked-bar` | Mixin applied to the slider when the input is not checked | `{}`
 `--paper-toggle-button-unchecked-button` | Mixin applied to the slider button when the input is not checked | `{}`
 `--paper-toggle-button-checked-bar` | Mixin applied to the slider when the input is checked | `{}`


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-toggle-button/issues/34

Re-checked the material design spec, and the default colour for all the controls is green (which I believe is just the sample colour they use). Since `paper-radio-button` and `paper-checkbox` all use the same `default-primary-color`, it makes sense that this should as well.

@cdata :wave:
