### PR TITLE
Move the default-theme import to the demo page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -17,7 +17,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta name="apple-mobile-web-app-capable" content="yes">
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
     <link rel="import" href="../../paper-styles/demo-pages.html">
+    <link rel="import" href="../../paper-styles/default-theme.html">
     <link rel="import" href="../paper-toggle-button.html">
 
     <style is="custom-style">

--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -10,7 +10,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-styles/color.html">
-<link rel="import" href="../paper-styles/default-theme.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
 <link rel="import" href="../paper-behaviors/paper-inky-focus-behavior.html">
 


### PR DESCRIPTION
I move this because we have problems when use elements and I want to change the :root{} custom properties. 
