### PR TITLE
solves #43: use classes as CSS selectors for some properties

### DIFF
--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -98,7 +98,7 @@ Custom property | Description | Default
         height: 14px;
       }
 
-      #toggleBar {
+      .toggle-bar {
         position: absolute;
         height: 100%;
         width: 100%;
@@ -108,16 +108,16 @@ Custom property | Description | Default
         transition: background-color linear .08s;
       }
 
-      :host([checked]) #toggleBar {
+      :host([checked]) .toggle-bar {
         opacity: 0.5;
       }
 
-      :host([disabled]) #toggleBar {
+      :host([disabled]) .toggle-bar {
         background-color: #000;
         opacity: 0.12;
       }
 
-      #toggleButton {
+      .toggle-button {
         position: absolute;
         top: -3px;
         height: 20px;
@@ -129,22 +129,22 @@ Custom property | Description | Default
         will-change: transform;
       }
 
-      #toggleButton.dragging {
+      .toggle-button.dragging {
         -webkit-transition: none;
         transition: none;
       }
 
-      :host([checked]) #toggleButton {
+      :host([checked]) .toggle-button {
         -webkit-transform: translate(16px, 0);
         transform: translate(16px, 0);
       }
 
-      :host([disabled]) #toggleButton {
+      :host([disabled]) .toggle-button {
         background-color: #bdbdbd;
         opacity: 1;
       }
 
-      #ink {
+      .toggle-ink {
         position: absolute;
         top: -14px;
         left: -14px;


### PR DESCRIPTION
use classes as CSS selectors for some properties instead of ids, so the properties declared in the mixins of the paper-toggle-button such as: 

``` css
--paper-toggle-button-checked-bar: {
border-radius: 2px;
};
--paper-toggle-button-checked-button: {...};
--paper-toggle-button-unchecked-bar: {...};
--paper-toggle-button-unchecked-button: {...};
```

can be applied without having to override them with the :hankey: !important :smiley: 
