### PR TITLE
use class selector for the toggleContainer also

### DIFF
--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -92,7 +92,7 @@ Custom property | Description | Default
 
       /* ID selectors should not be overriden by users. */
 
-      #toggleContainer {
+      .toggle-container {
         position: relative;
         width: 36px;
         height: 14px;
@@ -155,7 +155,7 @@ Custom property | Description | Default
       }
     </style>
 
-    <div id="toggleContainer">
+    <div id="toggleContainer" class="toggle-container">
       <div id="toggleBar" class="toggle-bar"></div>
       <div id="toggleButton" class="toggle-button">
         <paper-ripple id="ink" class="toggle-ink circle" recenters></paper-ripple>

--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -155,7 +155,7 @@ Custom property | Description | Default
       }
     </style>
 
-    <div id="toggleContainer" class="toggle-container">
+    <div class="toggle-container">
       <div id="toggleBar" class="toggle-bar"></div>
       <div id="toggleButton" class="toggle-button">
         <paper-ripple id="ink" class="toggle-ink circle" recenters></paper-ripple>


### PR DESCRIPTION
@notwaldorf I forgot to include the container to be css-selected by a class... even though it doesn't have a mixin applying to the .toggle-container/#toggleContainer, and therefore wouldn't be a problem...

I heard though it's a good practice to style selecting with classes rather than with ids, leaving ids for the interaction with JS etc (told me my senior colleague :) )

thanks!
