### PR TITLE
css typos are the best typos

### DIFF
--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -93,7 +93,7 @@ Custom property | Description | Default
         transition: none;
       }
 
-      :host([checked]):not([disabled]) .toggle-bar {
+      :host([checked]:not([disabled])) .toggle-bar {
         opacity: 0.5;
         background-color: var(--paper-toggle-button-checked-bar-color, --default-primary-color);
         @apply(--paper-toggle-button-checked-bar);
@@ -109,7 +109,7 @@ Custom property | Description | Default
         transform: translate(16px, 0);
       }
 
-      :host([checked]):not([disabled]) .toggle-button {
+      :host([checked]:not([disabled])) .toggle-button {
         background-color: var(--paper-toggle-button-checked-button-color, --default-primary-color);
         @apply(--paper-toggle-button-checked-button);
       }


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-toggle-button/issues/50 because past monica can't use selectors.
