### PR TITLE
Fixes #42

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -101,6 +101,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <paper-toggle-button checked class="blue">Calcium</paper-toggle-button>
         </div>
       </div>
+
+      <div>
+        <h4>Noink</h4>
+        <div class="horizontal-section">
+          <paper-toggle-button noink>Oxygen</paper-toggle-button>
+          <paper-toggle-button noink>Carbon</paper-toggle-button>
+          <paper-toggle-button checked noink>Hydrogen</paper-toggle-button>
+          <paper-toggle-button checked noink>Nitrogen</paper-toggle-button>
+          <paper-toggle-button checked noink>Calcium</paper-toggle-button>
+        </div>
+      </div>
     </div>
   </body>
 </html>

--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -12,7 +12,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../paper-styles/color.html">
 <link rel="import" href="../paper-styles/default-theme.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
-<link rel="import" href="../paper-behaviors/paper-inky-focus-behavior.html">
 <link rel="import" href="../paper-behaviors/paper-checked-element-behavior.html">
 
 <!--
@@ -170,7 +169,6 @@ Custom property | Description | Default
       is: 'paper-toggle-button',
 
       behaviors: [
-        Polymer.PaperInkyFocusBehavior,
         Polymer.PaperCheckedElementBehavior
       ],
 
@@ -195,20 +193,6 @@ Custom property | Description | Default
 
       listeners: {
         track: '_ontrack'
-      },
-
-      ready: function() {
-        this._isReady = true;
-      },
-
-      // button-behavior hook
-      _buttonStateChanged: function() {
-        if (this.disabled) {
-          return;
-        }
-        if (this._isReady) {
-          this.checked = this.active;
-        }
       },
 
       _ontrack: function(event) {

--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../paper-styles/default-theme.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
 <link rel="import" href="../paper-behaviors/paper-inky-focus-behavior.html">
-<link rel="import" href="../iron-checked-element-behavior/iron-checked-element-behavior.html">
+<link rel="import" href="../paper-behaviors/paper-checked-element-behavior.html">
 
 <!--
 Material design: [Switch](https://www.google.com/design/spec/components/selection-controls.html#selection-controls-switch)
@@ -50,7 +50,7 @@ Custom property | Description | Default
 -->
 
 <dom-module id="paper-toggle-button">
-  <template>
+  <template strip-whitespace>
 
     <style>
       :host {
@@ -158,9 +158,7 @@ Custom property | Description | Default
 
     <div class="toggle-container">
       <div id="toggleBar" class="toggle-bar"></div>
-      <div id="toggleButton" class="toggle-button">
-        <paper-ripple id="ink" class="toggle-ink circle" recenters></paper-ripple>
-      </div>
+      <div id="toggleButton" class="toggle-button"></div>
     </div>
 
     <div class="toggle-label"><content></content></div>
@@ -173,7 +171,7 @@ Custom property | Description | Default
 
       behaviors: [
         Polymer.PaperInkyFocusBehavior,
-        Polymer.IronCheckedElementBehavior
+        Polymer.PaperCheckedElementBehavior
       ],
 
       hostAttributes: {
@@ -245,6 +243,16 @@ Custom property | Description | Default
       _trackEnd: function(track) {
         this.$.toggleButton.classList.remove('dragging');
         this.transform('', this.$.toggleButton);
+      },
+
+      // customize the element's ripple
+      _createRipple: function() {
+        this._rippleContainer = this.$.toggleButton;
+        var ripple = Polymer.PaperRippleBehavior._createRipple();
+        ripple.id = 'ink';
+        ripple.setAttribute('recenters', '');
+        ripple.classList.add('circle', 'toggle-ink');
+        return ripple;
       }
 
     });


### PR DESCRIPTION
Fixes #42: Remove <paper-ripple> since PaperInkyFocusBehavior now manages this.

Should be merged after https://github.com/PolymerElements/paper-behaviors/pull/32/.
