### PR TITLE
add a custom property for the label spacing

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -25,7 +25,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <style is="custom-style" include="demo-pages-shared-styles">
       .vertical-section-container {
-        max-width: 600px;
+        max-width: 500px;
       }
 
       paper-toggle-button {
@@ -44,19 +44,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <paper-toggle-button disabled>Disabled</paper-toggle-button>
         </template>
       </demo-snippet>
-    </div>
 
-    <div class="vertical-section-container centered">
       <h3>Toggle buttons can hide the ripple effect using the <i>noink</i> attribute</h3>
       <demo-snippet class="centered-demo">
         <template>
           <paper-toggle-button noink>Toggle</paper-toggle-button>
         </template>
       </demo-snippet>
-    </div>
 
-    <div class="vertical-section-container centered">
-      <h3>Toggle buttons can be styled using custom properties</h3>
+    <h3>Toggle buttons can be styled using custom properties</h3>
       <demo-snippet class="centered-demo">
         <template>
           <style is="custom-style">

--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -41,6 +41,7 @@ Custom property | Description | Default
 `--paper-toggle-button-checked-bar` | Mixin applied to the slider when the input is checked | `{}`
 `--paper-toggle-button-checked-button` | Mixin applied to the slider button when the input is checked | `{}`
 `--paper-toggle-button-label-color` | Label color | `--primary-text-color`
+`--paper-toggle-button-label-spacing` | Spacing between the label and the button | `8px`
 
 @group Paper Elements
 @element paper-toggle-button
@@ -148,7 +149,7 @@ Custom property | Description | Default
         top: -2px;
         display: inline-block;
         vertical-align: middle;
-        margin-left: 10px;
+        padding-left: var(--paper-toggle-button-label-spacing, 8px);
         white-space: normal;
         pointer-events: none;
         color: var(--paper-toggle-button-label-color, --primary-text-color);


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-toggle-button/issues/64 by adding a custom property to control the label spacing (this is the same thing that `paper-checkbox` and `paper-radio-button` do)
