### PR TITLE
Remove unneeded paper-ripple import

### DIFF
--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -12,7 +12,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../paper-styles/color.html">
 <link rel="import" href="../paper-styles/default-theme.html">
-<link rel="import" href="../paper-ripple/paper-ripple.html">
 <link rel="import" href="../paper-behaviors/paper-checked-element-behavior.html">
 
 <!--


### PR DESCRIPTION
The `paper-behaviors/paper-checked-element-behavior.html` already import the `paper-ripple`.
