### PR TITLE
Remove white-space: normal; from label

### DIFF
--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -162,7 +162,6 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         display: inline-block;
         vertical-align: middle;
         padding-left: var(--paper-toggle-button-label-spacing, 8px);
-        white-space: normal;
         pointer-events: none;
         color: var(--paper-toggle-button-label-color, --primary-text-color);
       }


### PR DESCRIPTION
I've got a toggle button in a dropdown, and don't want the button's label to be wrapped if a scroll bar is displayed on the dropdown. However, I can't do this by styling the toggle button with `white-space: nowrap;`, because the label is styled with `white-space: normal;`. Since normal is the default, this commit removes it to allow clients to style the text content how they wish.
