### PR TITLE
Allow css customization for ripples.

### DIFF
--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -41,8 +41,10 @@ Custom property | Description | Default
 `--paper-toggle-button-invalid-ink-color` | Selected/focus ripple color when the input is invalid | `--error-color`
 `--paper-toggle-button-unchecked-bar` | Mixin applied to the slider when the input is not checked | `{}`
 `--paper-toggle-button-unchecked-button` | Mixin applied to the slider button when the input is not checked | `{}`
+`--paper-toggle-button-unchecked-ink` | Mixin applied to the ripple when the input is not checked | `{}`
 `--paper-toggle-button-checked-bar` | Mixin applied to the slider when the input is checked | `{}`
 `--paper-toggle-button-checked-button` | Mixin applied to the slider button when the input is checked | `{}`
+`--paper-toggle-button-checked-ink` | Mixin applied to the ripple when the input is checked | `{}`
 `--paper-toggle-button-label-color` | Label color | `--primary-text-color`
 `--paper-toggle-button-label-spacing` | Spacing between the label and the button | `8px`
 
@@ -147,10 +149,14 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         opacity: 0.5;
         pointer-events: none;
         color: var(--paper-toggle-button-unchecked-ink-color, --primary-text-color);
+
+        @apply(--paper-toggle-button-unchecked-ink);
       }
 
       :host([checked]) .toggle-ink {
         color: var(--paper-toggle-button-checked-ink-color, --primary-color);
+
+        @apply(--paper-toggle-button-checked-ink);
       }
 
       .toggle-container {


### PR DESCRIPTION
Currently, the consumers are allowed to customize size and positions for the toggle button and the bar, but not the ripple (with size and positions hardcoded). This results in weird visuals, such as the ripple being off-centered, or ripple being too big/small.

This PR allows consumers to customize the ripple styles to fit with the toggle button/bar style they specified.