### PR TITLE
2.0-preview fix afterNextRender

### DIFF
--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -227,7 +227,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       },
 
       attached: function() {
-        Polymer.RenderStatus.afterNextRender(this, function() {
+        Polymer.RenderStatus.afterNextRender(() => {
           Polymer.Gestures.setTouchAction(this, 'pan-y');
         });
       },

--- a/test/basic.html
+++ b/test/basic.html
@@ -40,7 +40,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('set scroll direction', function(done) {
-          Polymer.RenderStatus.afterNextRender(b1, function() {
+          Polymer.RenderStatus.afterNextRender(function() {
             assert.equal(b1.__polymerGesturesTouchAction, 'pan-y');
             done();
           });


### PR DESCRIPTION
Polymer 2 docs: 

* Polymer.RenderStatus.afterNextRender(context, callback, args) is now called only with a callback argument (Polymer.RenderStatus.afterNextRender(callback)). The callback should be bound as needed with the correct context and arguments.

https://github.com/Polymer/polymer/blob/2.0-preview/src/utils/render-status.html