### PR TITLE
Add property label to improve application binding

### DIFF
--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -197,7 +197,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       <div id="toggleButton" class="toggle-button"></div>
     </div>
 
-    <div class="toggle-label"><slot></slot></div>
+    <div class="toggle-label">[[label]]<slot></slot></div>
 
   </template>
 
@@ -216,6 +216,13 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       },
 
       properties: {
+        /**
+         * Provide a label
+         */
+        label: {
+         type: String,
+         reflectToAttribute: true
+        },
         /**
          * Fired when the checked state changes due to user interaction.
          *


### PR DESCRIPTION
There's currently no way to update the label on the element without destroying the contents of the element or creating a new "label" element outside of the toggle. By providing a `label` attribute you would be able to listen to change events on the toggle and then update the label to match the new state. Would also fix #106 or at least provide a way of supporting it.