### PR TITLE
add min-width to .toggle-container

### DIFF
--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -163,6 +163,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         display: inline-block;
         position: relative;
         width: 36px;
+        min-width: 36px;
         height: 14px;
         /* The toggle button has an absolute position of -3px; The extra 1px
         /* accounts for the toggle button shadow box. */


### PR DESCRIPTION
When you have a lot of text and it is in a small space, the element does not maintain the 36 px

fix:
 min-width: 36px;