### PR TITLE
`readonly` mode

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -48,6 +48,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </template>
       </demo-snippet>
 
+      <h3>Toggle buttons can be made read-only (not editable but still submitted)</h3>
+      <demo-snippet class="centered-demo">
+        <template>
+          <paper-toggle-button readonly>Read-only</paper-toggle-button>
+        </template>
+      </demo-snippet>
+
       <h3>Toggle buttons can hide the ripple effect using the <i>noink</i> attribute</h3>
       <demo-snippet class="centered-demo">
         <template>

--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -226,10 +226,16 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
          *
          * @event iron-change
          */
+        readonly: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true
+        }
       },
 
       listeners: {
-        track: '_ontrack'
+        track: '_ontrack',
+        tap: '_ontap'
       },
 
       attached: function() {
@@ -280,6 +286,13 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         ripple.setAttribute('recenters', '');
         ripple.classList.add('circle', 'toggle-ink');
         return ripple;
+      },
+      
+      _ontap: function(event) {
+        if (this.readonly) {
+            event.preventDefault();
+            return;
+        }
       }
 
     });

--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -234,8 +234,7 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
       },
 
       listeners: {
-        track: '_ontrack',
-        tap: '_ontap'
+        track: '_ontrack'
       },
 
       attached: function() {
@@ -288,11 +287,13 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
         return ripple;
       },
       
-      _ontap: function(event) {
+      _tapHandler: function(event) {
         if (this.readonly) {
-            event.preventDefault();
-            return;
+          event.preventDefault();
+          return;
         }
+        var spr = this.behaviors.find(function(b) { return b._tapHandler; });
+        if (spr) spr._tapHandler.apply(this, arguments);
       }
 
     });


### PR DESCRIPTION
Add support for `readonly` attribute on `paper-toggle-button`.

I'm not sure about my use of overriding IronButtonState's event handler, but that's the only way I could find to capture the tap early enough to be canceled elegantly, but more specifically I'm not sure about the syntax for calling the original event handler - though it seems to work well, at least on Polymer 2.