### PR TITLE
Listener tried to modify its DOM in the constructor

### DIFF
--- a/paper-toggle-button.html
+++ b/paper-toggle-button.html
@@ -228,13 +228,10 @@ In order to apply the `Roboto` font to this element, make sure you've imported `
          */
       },
 
-      listeners: {
-        track: '_ontrack'
-      },
-
       attached: function() {
         Polymer.RenderStatus.afterNextRender(this, function() {
           Polymer.Gestures.setTouchAction(this, 'pan-y');
+          this.addEventListener('track', this._ontrack.bind(this));
         });
       },
 


### PR DESCRIPTION
## Bug

 * Original code worked until Polymer 2.3.1. Since Polymer 2.4.0, Current paper-toggle-button does not work with error
```
Uncaught DOMException: Failed to construct 'CustomElement': The result must not have attributes
```

## Reason
 * Listener tried to modify its DOM in the constructor
 * The element's attributes and children must not be inspected, as in the non-upgrade case none will be present, and relying on upgrades makes the element less usable.
 * https://html.spec.whatwg.org/multipage/scripting.html#custom-element-conformance

## Solution

 * Can be solved by moving the listener binding to the `attached`.

