### PR TITLE
Add style support for disabled state

### DIFF
--- a/paper-toggle-button.js
+++ b/paper-toggle-button.js
@@ -161,7 +161,7 @@ Polymer({
 
       :host([disabled]) .toggle-button {
         background-color: var(--paper-toggle-button-unchecked-button-color, #bdbdbd);
-        opacity: 1;
+        opacity: 0.5;
 
         @apply(--paper-toggle-button-unchecked-button);
       }

--- a/paper-toggle-button.js
+++ b/paper-toggle-button.js
@@ -129,8 +129,16 @@ Polymer({
       }
 
       :host([disabled]) .toggle-bar {
-        background-color: #000;
+        background-color: var(--paper-toggle-button-unchecked-bar-color, #000);
         opacity: 0.12;
+
+        @apply(--paper-toggle-button-unchecked-bar);
+      }
+
+      :host([checked][disabled]) .toggle-bar {
+        background-color: var(--paper-toggle-button-checked-bar-color, #000);
+        
+        @apply(--paper-toggle-button-checked-bar);
       }
 
       :host([checked]) .toggle-button {
@@ -152,8 +160,16 @@ Polymer({
       }
 
       :host([disabled]) .toggle-button {
-        background-color: #bdbdbd;
+        background-color: var(--paper-toggle-button-unchecked-button-color, #bdbdbd);
         opacity: 1;
+
+        @apply(--paper-toggle-button-unchecked-button);
+      }
+
+      :host([checked][disabled]) .toggle-button {
+        background-color: var(--paper-toggle-button-checked-button-color, #bdbdbd);
+        
+        @apply(--paper-toggle-button-checked-button);
       }
 
       .toggle-ink {


### PR DESCRIPTION
Currently, it shows the default colors for disabled state which is not suitable if a website has more than one theme (say dark theme). 

Now, it will use the correct styles for the disabled state also.
- Added style support for disabled state.
- Reduced opacity for toggle button to 0.5 to make it distinguishable in disabled state.